### PR TITLE
Fixed: ansible state=touch cannot apply on symlink

### DIFF
--- a/tasks/trigger_reload.yml
+++ b/tasks/trigger_reload.yml
@@ -1,5 +1,3 @@
 - name: Trigger a reload
-  file:
-    path: "{{ django_touch_reload_path }}"
-    state: touch
+  command: touch "{{ django_touch_reload_path }}" warn=no
   when: "django_touch_reload_path != ''"


### PR DESCRIPTION
When the project folder is a symlink, the task `trigger_reload` will fail with the following error:

```
TASK [django-deploy : Trigger a reload] ****************************************
fatal: [default]: FAILED! => {"changed": false, "msg": "Cannot touch other than files, directories, and hardlinks (/opt/performcoop/project is link)"}
```

Changing it to a `touch` bash command resolves this problem, although ansible warns to use `state=touch` rather than running touch.